### PR TITLE
Correction of the growing context

### DIFF
--- a/Sources/AST/ASTContext.swift
+++ b/Sources/AST/ASTContext.swift
@@ -26,28 +26,12 @@ public final class ASTContext {
     typeConstraints.append(constraint)
   }
   
-  public func getFunctionTypes() -> [FunctionType] {
-    return functionTypes
+  public func removeLastFunctionTypes() {
+    self.functionTypes.removeLast()
   }
   
-  public func getTupleTypes() -> [TupleType] {
-    return tupleTypes
-  }
-  
-  public func getUnionTypes() -> [UnionType] {
-    return unionTypes
-  }
-
-  public func setFunctionTypes(functionTypes: [FunctionType]) {
-    self.functionTypes = functionTypes
-  }
-  
-  public func setTuplesTypes(tupleTypes: [TupleType]) {
-    self.tupleTypes = tupleTypes
-  }
-  
-  public func setUnionTypes(unionTypes: [UnionType]) {
-    self.unionTypes = unionTypes
+  public func removeLastTupleTypes() {
+    self.tupleTypes.removeLast()
   }
 
   /// Retrieves or create a function type.

--- a/Sources/AST/ASTContext.swift
+++ b/Sources/AST/ASTContext.swift
@@ -25,14 +25,6 @@ public final class ASTContext {
   public func add(constraint: Constraint) {
     typeConstraints.append(constraint)
   }
-  
-  public func removeLastFunctionTypes() {
-    self.functionTypes.removeLast()
-  }
-  
-  public func removeLastTupleTypes() {
-    self.tupleTypes.removeLast()
-  }
 
   /// Retrieves or create a function type.
   public func getFunctionType(from domain: TupleType, to codomain: TypeBase) -> FunctionType {

--- a/Sources/AST/ASTContext.swift
+++ b/Sources/AST/ASTContext.swift
@@ -16,11 +16,11 @@ public final class ASTContext {
   /// The type constraints that haven't been solved yet.
   public var typeConstraints: [Constraint] = []
   /// The function types in the context.
-  private var functionTypes: [FunctionType] = []
+  public var functionTypes: [FunctionType] = []
   /// The tuple types in the context.
-  private var tupleTypes: [TupleType] = []
+  public var tupleTypes: [TupleType] = []
   /// The union types in the context.
-  private var unionTypes: [UnionType] = []
+  public var unionTypes: [UnionType] = []
 
   public func add(constraint: Constraint) {
     typeConstraints.append(constraint)

--- a/Sources/AST/ASTContext.swift
+++ b/Sources/AST/ASTContext.swift
@@ -25,6 +25,30 @@ public final class ASTContext {
   public func add(constraint: Constraint) {
     typeConstraints.append(constraint)
   }
+  
+  public func getFunctionTypes() -> [FunctionType] {
+    return functionTypes
+  }
+  
+  public func getTupleTypes() -> [TupleType] {
+    return tupleTypes
+  }
+  
+  public func getUnionTypes() -> [UnionType] {
+    return unionTypes
+  }
+
+  public func setFunctionTypes(functionTypes: [FunctionType]) {
+    self.functionTypes = functionTypes
+  }
+  
+  public func setTuplesTypes(tupleTypes: [TupleType]) {
+    self.tupleTypes = tupleTypes
+  }
+  
+  public func setUnionTypes(unionTypes: [UnionType]) {
+    self.unionTypes = unionTypes
+  }
 
   /// Retrieves or create a function type.
   public func getFunctionType(from domain: TupleType, to codomain: TypeBase) -> FunctionType {

--- a/Sources/AST/ASTContext.swift
+++ b/Sources/AST/ASTContext.swift
@@ -16,14 +16,23 @@ public final class ASTContext {
   /// The type constraints that haven't been solved yet.
   public var typeConstraints: [Constraint] = []
   /// The function types in the context.
-  public var functionTypes: [FunctionType] = []
+  private var functionTypes: [FunctionType] = []
   /// The tuple types in the context.
-  public var tupleTypes: [TupleType] = []
+  private var tupleTypes: [TupleType] = []
   /// The union types in the context.
-  public var unionTypes: [UnionType] = []
+  private var unionTypes: [UnionType] = []
 
   public func add(constraint: Constraint) {
     typeConstraints.append(constraint)
+  }
+  
+  public func saveContext() -> ([FunctionType], [TupleType]){
+    return (functionTypes, tupleTypes)
+  }
+  
+  public func reloadContext(context: ([FunctionType], [TupleType])) {
+    self.functionTypes = context.0
+    self.tupleTypes = context.1
   }
 
   /// Retrieves or create a function type.

--- a/Sources/Interpreter/Interpreter.swift
+++ b/Sources/Interpreter/Interpreter.swift
@@ -41,11 +41,23 @@ public struct Interpreter {
     let parser = try Parser(source: input)
     let expr = try parser.parseExpr()
 
+    let originalFuncTypes = astContext.getFunctionTypes()
+    let originalTupleTypes = astContext.getTupleTypes()
+    let originalUnionTypes = astContext.getUnionTypes()
+    
     // Expressions can't be analyzed nor ran out-of-context, they must be nested in a module.
     let module = Module(statements: [expr], range: expr.range)
 
     // Run semantic analysis to get the typed AST.
     let typedModule = try runSema(on: module) as! Module
+    
+    // Reset different type contexts: Functions type, tuples types and union types
+    defer {
+      astContext.setFunctionTypes(functionTypes: originalFuncTypes)
+      astContext.setTuplesTypes(tupleTypes: originalTupleTypes)
+      astContext.setUnionTypes(unionTypes: originalUnionTypes)
+    }
+    
     return eval(expression: typedModule.statements[0] as! Expr)
   }
 

--- a/Sources/Interpreter/Interpreter.swift
+++ b/Sources/Interpreter/Interpreter.swift
@@ -36,7 +36,7 @@ public struct Interpreter {
   }
 
   // Evaluate an expression from a text input, within the currently loaded context.
-  public mutating func eval(string input: String) throws -> Value {
+  public func eval(string input: String) throws -> Value {
     
     // Parse the epxression into an untyped AST.
     let parser = try Parser(source: input)

--- a/Sources/Interpreter/Interpreter.swift
+++ b/Sources/Interpreter/Interpreter.swift
@@ -34,13 +34,17 @@ public struct Interpreter {
     astContext.modules.append(module)
     return module
   }
+  
+  public func saveContext() -> ([FunctionType], [TupleType]) {
+    return astContext.saveContext()
+  }
+  
+  public func reloadContext(context: ([FunctionType], [TupleType])) {
+    astContext.reloadContext(context: context)
+  }
 
   // Evaluate an expression from a text input, within the currently loaded context.
   public func eval(string input: String) throws -> Value {
-
-    // Keep the old context, avoiding to keep new functions from the input code
-    let tempFunctionTypes = astContext.functionTypes
-    let tempTupleTypes = astContext.tupleTypes
     
     // Parse the epxression into an untyped AST.
     let parser = try Parser(source: input)
@@ -54,13 +58,6 @@ public struct Interpreter {
 
     // Compute the evaluation
     let res = eval(expression: typedModule.statements[0] as! Expr)
-    
-    // Do not assign the old context if it was empty, cause the first time built-in functions are assigned
-    // We do not want remove them
-    if !tempFunctionTypes.isEmpty && !tempTupleTypes.isEmpty {
-      astContext.functionTypes = tempFunctionTypes
-      astContext.tupleTypes = tempTupleTypes
-    }
     
     return res
   }


### PR DESCRIPTION
I inspected the interpreter to look at where there was a problem with the growing context.
The problem was that every time a new input was executed, it was added to the current context by adding a function and a tuple.

Now, the context keeps only built-in functions and functions from the module. 
Otherwise, it is deleted after the execution.

Thus, the time execution is stable and has already been tested on my examples (from hero nets).